### PR TITLE
feat(qa): add Ctx.Eventually for polling assertions

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -1,6 +1,14 @@
 package qa
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
+
+type TestingT interface {
+	Helper()
+	Fatalf(format string, args ...any)
+}
 
 type Ctx[D any] struct {
 	T      *testing.T
@@ -10,4 +18,23 @@ type Ctx[D any] struct {
 
 func (c *Ctx[D]) Run(name string, fn func(*testing.T)) bool {
 	return c.T.Run(c.prefix+" "+name, fn)
+}
+
+// Eventually calls fn repeatedly until it returns nil or the window expires.
+// If fn never returns nil, the step is failed with the last returned error.
+func (c *Ctx[D]) Eventually(t TestingT, name string, window time.Duration, fn func() error) {
+	t.Helper()
+	deadline := time.Now().Add(window)
+	interval := window / 5
+	for {
+		err := fn()
+		if err == nil {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("%s %s: condition not met within %s: %v", c.prefix, name, window, err)
+			return
+		}
+		time.Sleep(interval)
+	}
 }

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -1,0 +1,80 @@
+package qa_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/kyuff/qa"
+)
+
+func newTestingTMock() *TestingTMock {
+	return &TestingTMock{
+		HelperFunc: func() {},
+		FatalfFunc: func(format string, args ...any) {},
+	}
+}
+
+func TestCtx_Eventually(t *testing.T) {
+	t.Run("should call Fatalf when fn never returns nil within window", func(t *testing.T) {
+		// arrange
+		var (
+			mock = newTestingTMock()
+			sut  = &qa.Ctx[struct{}]{}
+		)
+
+		// act
+		sut.Eventually(mock, "condition", 50*time.Millisecond, func() error {
+			return errors.New("always failing")
+		})
+
+		// assert
+		if len(mock.FatalfCalls()) == 0 {
+			t.Error("expected Fatalf to be called when fn never returns nil")
+		}
+	})
+
+	t.Run("should not call Fatalf when fn returns nil on first attempt", func(t *testing.T) {
+		// arrange
+		var (
+			mock = newTestingTMock()
+			sut  = &qa.Ctx[struct{}]{}
+		)
+
+		// act
+		sut.Eventually(mock, "condition", time.Second, func() error {
+			return nil
+		})
+
+		// assert
+		if len(mock.FatalfCalls()) != 0 {
+			t.Error("expected Fatalf not to be called when fn returns nil")
+		}
+	})
+
+	t.Run("should not call Fatalf when fn eventually returns nil within window", func(t *testing.T) {
+		// arrange
+		var (
+			mock  = newTestingTMock()
+			sut   = &qa.Ctx[struct{}]{}
+			calls = 0
+		)
+
+		// act
+		sut.Eventually(mock, "condition", time.Second, func() error {
+			calls++
+			if calls < 3 {
+				return errors.New("not ready yet")
+			}
+			return nil
+		})
+
+		// assert
+		if len(mock.FatalfCalls()) != 0 {
+			t.Error("expected Fatalf not to be called when fn eventually returns nil")
+		}
+		if calls < 3 {
+			t.Errorf("expected at least 3 calls, got %d", calls)
+		}
+	})
+}

--- a/gen.go
+++ b/gen.go
@@ -1,3 +1,3 @@
 package qa
 
-//go:generate go tool moq -out mocks_test.go -pkg qa_test . Stub
+//go:generate go tool moq -out mocks_test.go -pkg qa_test . Stub TestingT

--- a/mocks_test.go
+++ b/mocks_test.go
@@ -193,3 +193,112 @@ func (mock *StubMock) StopCalls() []struct {
 	mock.lockStop.RUnlock()
 	return calls
 }
+
+// Ensure, that TestingTMock does implement qa.TestingT.
+// If this is not the case, regenerate this file with moq.
+var _ qa.TestingT = &TestingTMock{}
+
+// TestingTMock is a mock implementation of qa.TestingT.
+//
+//	func TestSomethingThatUsesTestingT(t *testing.T) {
+//
+//		// make and configure a mocked qa.TestingT
+//		mockedTestingT := &TestingTMock{
+//			FatalfFunc: func(format string, args ...any)  {
+//				panic("mock out the Fatalf method")
+//			},
+//			HelperFunc: func()  {
+//				panic("mock out the Helper method")
+//			},
+//		}
+//
+//		// use mockedTestingT in code that requires qa.TestingT
+//		// and then make assertions.
+//
+//	}
+type TestingTMock struct {
+	// FatalfFunc mocks the Fatalf method.
+	FatalfFunc func(format string, args ...any)
+
+	// HelperFunc mocks the Helper method.
+	HelperFunc func()
+
+	// calls tracks calls to the methods.
+	calls struct {
+		// Fatalf holds details about calls to the Fatalf method.
+		Fatalf []struct {
+			// Format is the format argument value.
+			Format string
+			// Args is the args argument value.
+			Args []any
+		}
+		// Helper holds details about calls to the Helper method.
+		Helper []struct {
+		}
+	}
+	lockFatalf sync.RWMutex
+	lockHelper sync.RWMutex
+}
+
+// Fatalf calls FatalfFunc.
+func (mock *TestingTMock) Fatalf(format string, args ...any) {
+	if mock.FatalfFunc == nil {
+		panic("TestingTMock.FatalfFunc: method is nil but TestingT.Fatalf was just called")
+	}
+	callInfo := struct {
+		Format string
+		Args   []any
+	}{
+		Format: format,
+		Args:   args,
+	}
+	mock.lockFatalf.Lock()
+	mock.calls.Fatalf = append(mock.calls.Fatalf, callInfo)
+	mock.lockFatalf.Unlock()
+	mock.FatalfFunc(format, args...)
+}
+
+// FatalfCalls gets all the calls that were made to Fatalf.
+// Check the length with:
+//
+//	len(mockedTestingT.FatalfCalls())
+func (mock *TestingTMock) FatalfCalls() []struct {
+	Format string
+	Args   []any
+} {
+	var calls []struct {
+		Format string
+		Args   []any
+	}
+	mock.lockFatalf.RLock()
+	calls = mock.calls.Fatalf
+	mock.lockFatalf.RUnlock()
+	return calls
+}
+
+// Helper calls HelperFunc.
+func (mock *TestingTMock) Helper() {
+	if mock.HelperFunc == nil {
+		panic("TestingTMock.HelperFunc: method is nil but TestingT.Helper was just called")
+	}
+	callInfo := struct {
+	}{}
+	mock.lockHelper.Lock()
+	mock.calls.Helper = append(mock.calls.Helper, callInfo)
+	mock.lockHelper.Unlock()
+	mock.HelperFunc()
+}
+
+// HelperCalls gets all the calls that were made to Helper.
+// Check the length with:
+//
+//	len(mockedTestingT.HelperCalls())
+func (mock *TestingTMock) HelperCalls() []struct {
+} {
+	var calls []struct {
+	}
+	mock.lockHelper.RLock()
+	calls = mock.calls.Helper
+	mock.lockHelper.RUnlock()
+	return calls
+}

--- a/suite_test.go
+++ b/suite_test.go
@@ -53,3 +53,4 @@ func TestSuite(t *testing.T) {
 		then.ResultIsAccepted()
 	})
 }
+


### PR DESCRIPTION
## Summary

- Adds `Ctx.Eventually(t TestingT, name string, window time.Duration, fn func() error)` for eventually-true assertions in BDD-style tests
- Polls `fn` every `window/5` until it returns `nil` or the deadline passes, then fails the test with the last error
- Introduces a `TestingT` interface (`Helper` + `Fatalf`) so callers pass `*testing.T` and tests use the moq-generated `TestingTMock`

## Test plan

- [ ] `TestCtx_Eventually` covers error path (Fatalf called), success on first attempt, and success after retries
- [ ] All existing tests still pass (`go test ./... -count 1 -race`)
