### PR TITLE
feat: improve local app I/O handling and sync go.mod tool

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kyuff/qa
 
-go 1.26
+go 1.26.2
 
 tool github.com/matryer/moq
 

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,9 @@
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/matryer/moq v0.7.1 h1:/QaXqMAdOrLqlshW2z7SMS21jDi7aVrbW0wJrR+hhJk=
 github.com/matryer/moq v0.7.1/go.mod h1:IabIiFkaKCyHxej25INgFR+fnOxSZFMv2LYrU+ioyDs=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 golang.org/x/mod v0.23.0 h1:Zb7khfcRGKk+kqfxFaP5tZqCnDZMjC5VtUBs87Hr6QM=
 golang.org/x/mod v0.23.0/go.mod h1:6SkKJ3Xj0I0BrPOZoBy3bdMptDDU9oJrpohJ3eWZ1fY=
 golang.org/x/sync v0.11.0 h1:GGz8+XQP4FvTTrjZPzNKTMFtSXH80RAzG+5ghFPgK9w=

--- a/testapp/local_app.go
+++ b/testapp/local_app.go
@@ -2,8 +2,11 @@ package testapp
 
 import (
 	"context"
+	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"sync"
 )
 
 type appController interface {
@@ -21,14 +24,59 @@ type localApp struct {
 func (a *localApp) start(_ context.Context) error {
 	a.done = make(chan struct{})
 	a.proc = exec.Command(a.cmd, a.args...) //nolint:gosec
-	a.proc.Stdout = os.Stdout
-	a.proc.Stderr = os.Stderr
-	if err := a.proc.Start(); err != nil {
+
+	// Run from the module root so that relative paths like ./cmd/server/main.go
+	// resolve correctly regardless of which package directory go test runs from.
+	if dir := moduleRoot(); dir != "" {
+		a.proc.Dir = dir
+	}
+
+	// Use pipes instead of os.Stdout/os.Stderr directly. If the subprocess
+	// keeps an inherited FD open after the test exits, the Go test runner
+	// reports "Test I/O incomplete". Pipes break that reference: the parent
+	// closes its write-end after Start, so the read-end reaches EOF as soon
+	// as the child exits.
+	stdoutR, stdoutW, err := os.Pipe()
+	if err != nil {
 		return err
 	}
+	stderrR, stderrW, err := os.Pipe()
+	if err != nil {
+		stdoutR.Close()
+		stdoutW.Close()
+		return err
+	}
+	a.proc.Stdout = stdoutW
+	a.proc.Stderr = stderrW
+
+	if err := a.proc.Start(); err != nil {
+		stdoutR.Close()
+		stdoutW.Close()
+		stderrR.Close()
+		stderrW.Close()
+		return err
+	}
+
+	// Close write-ends in the parent so reads reach EOF when the child exits.
+	stdoutW.Close()
+	stderrW.Close()
+
 	go func() {
 		defer close(a.done)
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			io.Copy(os.Stdout, stdoutR) //nolint:errcheck
+			stdoutR.Close()
+		}()
+		go func() {
+			defer wg.Done()
+			io.Copy(os.Stderr, stderrR) //nolint:errcheck
+			stderrR.Close()
+		}()
 		a.proc.Wait() //nolint:errcheck
+		wg.Wait()
 	}()
 	return nil
 }
@@ -43,5 +91,23 @@ func (a *localApp) stop(ctx context.Context) {
 	case <-ctx.Done():
 		a.proc.Process.Kill() //nolint:errcheck
 		<-a.done
+	}
+}
+
+// moduleRoot walks up from the current directory to find the nearest go.mod.
+func moduleRoot() string {
+	dir, err := os.Getwd()
+	if err != nil {
+		return ""
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return ""
+		}
+		dir = parent
 	}
 }


### PR DESCRIPTION
## Summary

Changes developed in-place in [power-data](https://github.com/kyuff/power-data) under `lib/qa/` and synced here.

- **`testapp/local_app.go`**: switch from inheriting `os.Stdout`/`os.Stderr` directly to using pipes. When a subprocess keeps an inherited FD open after the test exits, the Go test runner reports "Test I/O incomplete". Pipes break that reference — the parent closes its write-end after `Start`, so the read-end reaches EOF as soon as the child exits. Also adds `moduleRoot()` helper to run from the module root regardless of which directory `go test` is invoked from.
- **`go.mod`**: add `tool github.com/matryer/moq` (required by `//go:generate` in `gen.go`) and update to `go 1.26.2`.
- **`go.sum`**: updated to match.

## Test plan

- [ ] `go test ./...` passes
- [ ] `go generate ./...` works (moq available as a tool)